### PR TITLE
Enable server storage for shared experiences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.html
+++ b/index.html
@@ -816,6 +816,60 @@
       return params.get(param);
     }
 
+const SERVER_URL = "http://localhost:3000";
+
+async function saveExperienceToServer(exp) {
+  try {
+    const res = await fetch(`${SERVER_URL}/experiences`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(exp)
+    });
+    if (res.ok) {
+      const data = await res.json();
+      return data.id;
+    }
+  } catch (e) {
+    console.error('Error saving experience to server', e);
+  }
+  return null;
+}
+
+async function loadExperienceFromServer(id) {
+  try {
+    const res = await fetch(`${SERVER_URL}/experiences/${id}`);
+    if (res.ok) {
+      return await res.json();
+    }
+  } catch (e) {
+    console.error('Error loading experience from server', e);
+  }
+  return null;
+}
+
+async function sendAnalyticsToServer(record) {
+  try {
+    await fetch(`${SERVER_URL}/analytics`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(record)
+    });
+  } catch (e) {
+    console.error('Error sending analytics to server', e);
+  }
+}
+
+async function fetchAnalyticsFromServer() {
+  try {
+    const res = await fetch(`${SERVER_URL}/analytics`);
+    if (res.ok) {
+      analyticsData = await res.json();
+      localStorage.setItem("analyticsData", JSON.stringify(analyticsData));
+    }
+  } catch (e) {
+    console.error('Error fetching analytics from server', e);
+  }
+}
     /**********************
      * IndexedDB Helpers  *
      **********************/
@@ -873,17 +927,23 @@
       const experienceIdParam = getQueryParam("experienceId");
       if (experienceIdParam) {
         try {
-          const data = await dbGet('tempExperiences', experienceIdParam);
+          let data = await dbGet('tempExperiences', experienceIdParam);
+          if (!data) {
+            data = await loadExperienceFromServer(experienceIdParam);
+            if (data) {
+              await dbSet('tempExperiences', { id: experienceIdParam, ...data });
+            }
+          }
           if (data) {
             sections = data.sections;
             currentExperienceName = data.name || null;
             isClientView = true;
           } else {
-            console.error('Experience ID not found in storage.');
+            console.error('Experience ID not found.');
             alert('Error: Experience not found.');
           }
         } catch (e) {
-          console.error('Error loading experience from storage:', e);
+          console.error('Error loading experience:', e);
           alert('Error loading experience data.');
         }
       }
@@ -1449,18 +1509,18 @@
       pdf.save("gehl-homes-brochure.pdf");
 
       // Store in analytics
-      analyticsData.push({
+      const record = {
         id: pdfId,
         email: email,
         count: selectedImages.size,
         pdfBase64: pdfBase64
-      });
+      };
+      analyticsData.push(record);
       localStorage.setItem("analyticsData", JSON.stringify(analyticsData));
+      await sendAnalyticsToServer(record);
+      await fetchAnalyticsFromServer();
       renderAdmin(); // Refresh Admin to show new submission
     }
-
-    function downloadUserPDF(pdfId) {
-      const record = analyticsData.find(rec => rec.id === pdfId);
       if (record && record.pdfBase64) {
         const link = document.createElement('a');
         link.href = record.pdfBase64;
@@ -1483,16 +1543,17 @@
       linkButtons.style.display = "none";
       setTimeout(async () => {
         try {
-          // Generate unique experience ID
-          const experienceId = Date.now().toString();
-          // Store experience in IndexedDB
+          const name = currentExperienceName || 'Untitled Experience';
+          const experienceId = await saveExperienceToServer({
+            sections: JSON.parse(JSON.stringify(sections)),
+            name: name
+          }) || Date.now().toString();
           await dbSet('tempExperiences', {
             id: experienceId,
             sections: JSON.parse(JSON.stringify(sections)),
-            name: currentExperienceName || 'Untitled Experience'
+            name: name
           });
-          // Generate shareable link with experienceId
-          const nameSlug = (currentExperienceName || 'Untitled').trim().replace(/\s+/g, '-').toLowerCase();
+          const nameSlug = name.trim().replace(/\s+/g, "-").toLowerCase();
           generatedLink = `${window.location.origin}${window.location.pathname}?experienceId=${experienceId}&experience=${encodeURIComponent(nameSlug)}`;
           autoSaveCurrentExperience();
           spinner.style.display = "none";
@@ -1881,6 +1942,7 @@
      ***********************/
     async function main() {
       await migrateSavedExperiences();
+      await fetchAnalyticsFromServer();
       await initFromUrl();
       if (isClientView) {
         document.getElementById("navbar").style.display = "none";

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "design-tool-server",
+  "version": "1.0.0",
+  "main": "server.js",
+  "license": "MIT",
+  "dependencies": {
+    "express": "^4.19.2",
+    "cors": "^2.8.5"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,63 @@
+const express = require('express');
+const fs = require('fs');
+const cors = require('cors');
+
+const app = express();
+app.use(express.json({ limit: '10mb' }));
+app.use(cors());
+
+const DATA_FILE = 'data.json';
+let data = { experiences: {}, analytics: [] };
+if (fs.existsSync(DATA_FILE)) {
+  try {
+    data = JSON.parse(fs.readFileSync(DATA_FILE));
+  } catch (e) {
+    console.error('Failed to parse data file:', e);
+  }
+}
+
+function saveData() {
+  fs.writeFileSync(DATA_FILE, JSON.stringify(data, null, 2));
+}
+
+// Save new experience and return id
+app.post('/experiences', (req, res) => {
+  const id = Date.now().toString();
+  const { sections, name } = req.body;
+  data.experiences[id] = { sections, name };
+  saveData();
+  res.json({ id });
+});
+
+// Get experience by id
+app.get('/experiences/:id', (req, res) => {
+  const exp = data.experiences[req.params.id];
+  if (exp) {
+    res.json(exp);
+  } else {
+    res.status(404).json({ error: 'Not found' });
+  }
+});
+
+// Add analytics record
+app.post('/analytics', (req, res) => {
+  const record = {
+    id: Date.now().toString(),
+    email: req.body.email,
+    count: req.body.count,
+    pdfBase64: req.body.pdfBase64,
+  };
+  data.analytics.push(record);
+  saveData();
+  res.json({ success: true });
+});
+
+// Fetch analytics records
+app.get('/analytics', (req, res) => {
+  res.json(data.analytics);
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add Express server to store experiences and analytics
- persist analytics on the server when generating PDFs
- load analytics from the server at startup
- generate client links via server API

## Testing
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6843b5fa446083278e924257bbc12afc