### PR TITLE
Add Memberstack and Supabase integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Design Tool SaaS
+
+This repository contains a simple Node server and single-page application for building experiences. The app now supports per-user data storage via Supabase and integrates with Memberstack for authentication on the client side.
+
+## Environment Variables
+
+- `SUPABASE_URL` – URL of your Supabase project
+- `SUPABASE_KEY` – service role or anon key
+- `DATA_FILE` – optional path to JSON file used when Supabase is not configured
+
+Create these variables when deploying on Render or another platform.
+
+## Running
+
+```
+npm start
+```
+
+The server listens on `PORT` (defaults to 3000).

--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
   <!-- Load fonts from Google Fonts -->
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Bangers&display=swap" rel="stylesheet">
+  <!-- Memberstack for authentication -->
+  <script src="https://static.memberstack.com/scripts/v1/memberstack.js" data-memberstack-app-id="YOUR_MEMBERSTACK_APP_ID" defer></script>
   <style>
     * {
       box-sizing: border-box;
@@ -807,6 +809,7 @@
      * Global Data & Initialization
      ******************************/
     let sections = [];
+    let memberId = null; // Memberstack user ID
     const defaultSectionNames = [
       "Exteriors", 
       "Interiors", 
@@ -860,20 +863,7 @@
     const adminPassword = "admin"; // Simple password; change for production
     let adminLoggedIn = localStorage.getItem("adminLoggedIn") === "true";
 
-    if (!isClientView) {
-      fetch('/experiences')
-        .then(r => (r.ok ? r.json() : []))
-        .then(list => {
-          savedExperiences = list;
-          if (adminLoggedIn) renderAdmin();
-        });
-      fetch('/analytics')
-        .then(r => (r.ok ? r.json() : []))
-        .then(list => {
-          analyticsData = list;
-          if (adminLoggedIn) renderAdmin();
-        });
-    }
+
 
     /*****************************
      * Helper: Read File as Data *
@@ -1407,7 +1397,8 @@
         id: pdfId,
         email: email,
         count: selectedImages.size,
-        pdfBase64: pdfBase64
+        pdfBase64: pdfBase64,
+        userId: memberId
       };
       fetch('/analytics', {
         method: 'POST',
@@ -1447,7 +1438,8 @@
 
       const payload = {
         sections: JSON.parse(JSON.stringify(sections)),
-        name: currentExperienceName || 'Untitled Experience'
+        name: currentExperienceName || 'Untitled Experience',
+        userId: memberId
       };
       const method = editingExperienceId ? 'PUT' : 'POST';
       const url = editingExperienceId
@@ -1596,7 +1588,8 @@
       }
       const payload = {
         name: name,
-        sections: JSON.parse(JSON.stringify(sections))
+        sections: JSON.parse(JSON.stringify(sections)),
+        userId: memberId
       };
       fetch('/experiences', {
         method: 'POST',
@@ -1653,7 +1646,8 @@
         if (index !== -1) {
           const payload = {
             name: currentExperienceName,
-            sections: JSON.parse(JSON.stringify(sections))
+            sections: JSON.parse(JSON.stringify(sections)),
+            userId: memberId
           };
           fetch(`/experiences/${editingExperienceId}`, {
             method: 'PUT',
@@ -1750,13 +1744,14 @@
         document.getElementById("duplicate-name-error").style.display = "block";
         return;
       }
-      if (duplicatingExperienceIndex !== null) {
-        const exp = savedExperiences[duplicatingExperienceIndex];
-        const payload = {
-          name: name,
-          sections: JSON.parse(JSON.stringify(exp.sections))
-        };
-        fetch('/experiences', {
+        if (duplicatingExperienceIndex !== null) {
+          const exp = savedExperiences[duplicatingExperienceIndex];
+          const payload = {
+            name: name,
+            sections: JSON.parse(JSON.stringify(exp.sections)),
+            userId: memberId
+          };
+          fetch('/experiences', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload)
@@ -1952,9 +1947,37 @@
       }
     }
 
-    initialRender();
+    function startApp() {
+      if (!isClientView) {
+        const query = memberId ? `?userId=${encodeURIComponent(memberId)}` : '';
+        fetch('/experiences' + query)
+          .then(r => (r.ok ? r.json() : []))
+          .then(list => {
+            savedExperiences = list;
+            if (adminLoggedIn) renderAdmin();
+          });
+        fetch('/analytics' + query)
+          .then(r => (r.ok ? r.json() : []))
+          .then(list => {
+            analyticsData = list;
+            if (adminLoggedIn) renderAdmin();
+          });
+      }
+      initialRender();
+    }
 
     window.addEventListener('beforeunload', autoSaveCurrentExperience);
+
+    if (window.$memberstackDom) {
+      window.$memberstackDom.getCurrentMember()
+        .then(({ data: member }) => {
+          if (member) memberId = member.id;
+          startApp();
+        })
+        .catch(startApp);
+    } else {
+      startApp();
+    }
   </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -6,5 +6,8 @@
   "scripts": {
     "start": "node server.js"
   },
-  "dependencies": {}
+  "dependencies": {
+    "@supabase/supabase-js": "^2.15.0",
+    "dotenv": "^16.3.1"
+  }
 }

--- a/server.js
+++ b/server.js
@@ -3,13 +3,22 @@ const fs = require('fs');
 const path = require('path');
 const { URL } = require('url');
 const os = require('os');
+try { require('dotenv').config(); } catch {}
+let createClient = null;
+try { ({ createClient } = require('@supabase/supabase-js')); } catch {}
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_KEY;
+const supabase = supabaseUrl && supabaseKey && createClient
+  ? createClient(supabaseUrl, supabaseKey)
+  : null;
 
 // Allow specifying a custom path for the data file so deployments can
 // store it on a persistent volume. Defaults to "data.json" in the
 // application directory.
 const DATA_FILE = process.env.DATA_FILE || 'data.json';
 let data = { experiences: {}, analytics: [] };
-if (fs.existsSync(DATA_FILE)) {
+if (!supabase && fs.existsSync(DATA_FILE)) {
   try {
     data = JSON.parse(fs.readFileSync(DATA_FILE));
   } catch (e) {
@@ -18,7 +27,9 @@ if (fs.existsSync(DATA_FILE)) {
 }
 
 function saveData() {
-  fs.writeFileSync(DATA_FILE, JSON.stringify(data, null, 2));
+  if (!supabase) {
+    fs.writeFileSync(DATA_FILE, JSON.stringify(data, null, 2));
+  }
 }
 
 function getLocalAddress() {
@@ -55,7 +66,104 @@ function parseRequestBody(req, callback) {
   });
 }
 
-const server = http.createServer((req, res) => {
+async function dbInsertExperience(userId, sections, name) {
+  if (supabase) {
+    const { data: rows, error } = await supabase
+      .from('experiences')
+      .insert({ user_id: userId, sections, name })
+      .select('id')
+      .single();
+    if (error) throw error;
+    return rows.id;
+  }
+  const id = Date.now().toString();
+  data.experiences[id] = { sections, name, userId };
+  saveData();
+  return id;
+}
+
+async function dbListExperiences(userId) {
+  if (supabase) {
+    const { data: rows, error } = await supabase
+      .from('experiences')
+      .select('id,name,sections')
+      .eq('user_id', userId);
+    if (error) throw error;
+    return rows;
+  }
+  return Object.entries(data.experiences)
+    .filter(([_, exp]) => exp.userId === userId)
+    .map(([id, exp]) => ({ id, name: exp.name, sections: exp.sections }));
+}
+
+async function dbGetExperience(id) {
+  if (supabase) {
+    const { data: row, error } = await supabase
+      .from('experiences')
+      .select('id,name,sections,user_id')
+      .eq('id', id)
+      .single();
+    if (error) return null;
+    return row;
+  }
+  return data.experiences[id] ? { id, ...data.experiences[id] } : null;
+}
+
+async function dbUpdateExperience(id, sections, name) {
+  if (supabase) {
+    const { error } = await supabase
+      .from('experiences')
+      .update({ sections, name })
+      .eq('id', id);
+    if (error) throw error;
+    return true;
+  }
+  if (data.experiences[id]) {
+    data.experiences[id] = { sections, name, userId: data.experiences[id].userId };
+    saveData();
+    return true;
+  }
+  return false;
+}
+
+async function dbDeleteExperience(id) {
+  if (supabase) {
+    const { error } = await supabase.from('experiences').delete().eq('id', id);
+    if (error) throw error;
+    return true;
+  }
+  if (data.experiences[id]) {
+    delete data.experiences[id];
+    saveData();
+    return true;
+  }
+  return false;
+}
+
+async function dbInsertAnalytics(record) {
+  if (supabase) {
+    const { error } = await supabase.from('analytics').insert(record);
+    if (error) throw error;
+    return true;
+  }
+  data.analytics.push(record);
+  saveData();
+  return true;
+}
+
+async function dbListAnalytics(userId) {
+  if (supabase) {
+    const { data: rows, error } = await supabase
+      .from('analytics')
+      .select()
+      .eq('user_id', userId);
+    if (error) throw error;
+    return rows;
+  }
+  return data.analytics.filter(a => a.userId === userId);
+}
+
+const server = http.createServer(async (req, res) => {
   // CORS preflight
   if (req.method === 'OPTIONS') {
     res.writeHead(204, {
@@ -88,76 +196,105 @@ const server = http.createServer((req, res) => {
   }
 
   if (req.method === 'POST' && url.pathname === '/experiences') {
-    return parseRequestBody(req, body => {
-      const id = Date.now().toString();
-      const { sections, name } = body;
-      data.experiences[id] = { sections, name };
-      saveData();
-      sendJson(res, 200, { id });
+    return parseRequestBody(req, async body => {
+      try {
+        const id = await dbInsertExperience(body.userId, body.sections, body.name);
+        sendJson(res, 200, { id });
+      } catch (e) {
+        console.error(e);
+        sendJson(res, 500, { error: 'server' });
+      }
     });
   }
 
   if (req.method === 'GET' && url.pathname === '/experiences') {
-    const exps = Object.entries(data.experiences).map(([id, exp]) => ({
-      id,
-      ...exp
-    }));
-    return sendJson(res, 200, exps);
+    const userId = url.searchParams.get('userId');
+    try {
+      const exps = await dbListExperiences(userId);
+      return sendJson(res, 200, exps);
+    } catch (e) {
+      console.error(e);
+      return sendJson(res, 500, { error: 'server' });
+    }
   }
 
   if (req.method === 'GET' && url.pathname.startsWith('/experiences/')) {
     const id = url.pathname.split('/')[2];
-    const exp = data.experiences[id];
-    if (exp) {
-      sendJson(res, 200, exp);
-    } else {
-      sendJson(res, 404, { error: 'Not found' });
+    try {
+      const exp = await dbGetExperience(id);
+      if (exp) {
+        sendJson(res, 200, exp);
+      } else {
+        sendJson(res, 404, { error: 'Not found' });
+      }
+    } catch (e) {
+      console.error(e);
+      sendJson(res, 500, { error: 'server' });
     }
     return;
   }
 
   if (req.method === 'PUT' && url.pathname.startsWith('/experiences/')) {
     const id = url.pathname.split('/')[2];
-    return parseRequestBody(req, body => {
-      if (data.experiences[id]) {
-        const { sections, name } = body;
-        data.experiences[id] = { sections, name };
-        saveData();
-        sendJson(res, 200, { success: true });
-      } else {
-        sendJson(res, 404, { error: 'Not found' });
+    return parseRequestBody(req, async body => {
+      try {
+        const updated = await dbUpdateExperience(id, body.sections, body.name);
+        if (updated) {
+          sendJson(res, 200, { success: true });
+        } else {
+          sendJson(res, 404, { error: 'Not found' });
+        }
+      } catch (e) {
+        console.error(e);
+        sendJson(res, 500, { error: 'server' });
       }
     });
   }
 
   if (req.method === 'DELETE' && url.pathname.startsWith('/experiences/')) {
     const id = url.pathname.split('/')[2];
-    if (data.experiences[id]) {
-      delete data.experiences[id];
-      saveData();
-      sendJson(res, 200, { success: true });
-    } else {
-      sendJson(res, 404, { error: 'Not found' });
+    try {
+      const deleted = await dbDeleteExperience(id);
+      if (deleted) {
+        sendJson(res, 200, { success: true });
+      } else {
+        sendJson(res, 404, { error: 'Not found' });
+      }
+    } catch (e) {
+      console.error(e);
+      sendJson(res, 500, { error: 'server' });
     }
     return;
   }
 
   if (req.method === 'POST' && url.pathname === '/analytics') {
-    return parseRequestBody(req, body => {
+    return parseRequestBody(req, async body => {
       const record = {
         id: Date.now().toString(),
         email: body.email,
         count: body.count,
-        pdfBase64: body.pdfBase64
+        pdfBase64: body.pdfBase64,
+        user_id: body.userId
       };
-      data.analytics.push(record);
-      saveData();
-      sendJson(res, 200, { success: true });
+      try {
+        await dbInsertAnalytics(record);
+        sendJson(res, 200, { success: true });
+      } catch (e) {
+        console.error(e);
+        sendJson(res, 500, { error: 'server' });
+      }
     });
   }
 
   if (req.method === 'GET' && url.pathname === '/analytics') {
-    return sendJson(res, 200, data.analytics);
+    const userId = url.searchParams.get('userId');
+    try {
+      const rows = await dbListAnalytics(userId);
+      return sendJson(res, 200, rows);
+    } catch (e) {
+      console.error(e);
+      return sendJson(res, 500, { error: 'server' });
+    }
   }
 
   sendJson(res, 404, { error: 'Not found' });


### PR DESCRIPTION
## Summary
- add Memberstack script and userId support to frontend
- move experience and analytics data to Supabase on the backend
- fallback to file storage if Supabase isn't configured
- document environment variables and running instructions

## Testing
- `npm start --silent`

------
https://chatgpt.com/codex/tasks/task_e_68448876a43c8327b41983710994f9e2