### PR TITLE
Implement simple username/password auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Design Tool SaaS
 
-This repository contains a simple Node server and single-page application for building experiences. The app now supports per-user data storage via Supabase and uses Memberstack for user authentication. Visitors must log in or sign up before accessing the builder.
+This repository contains a simple Node server and single-page application for building experiences. A built-in username/password system handles authentication. The default account is `gehlhomes` with password `GEadmin`, and additional users can sign up to create their own experiences. All data is stored per user and may optionally be backed by Supabase.
 
 ## Environment Variables
 

--- a/index.html
+++ b/index.html
@@ -9,8 +9,6 @@
   <!-- Load fonts from Google Fonts -->
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Bangers&display=swap" rel="stylesheet">
-  <!-- Memberstack for authentication -->
-  <script src="https://static.memberstack.com/scripts/v1/memberstack.js" data-memberstack-app-id="YOUR_MEMBERSTACK_APP_ID" defer></script>
   <style>
     * {
       box-sizing: border-box;
@@ -664,30 +662,21 @@
     <button id="nav-admin" onclick="showPage('admin')">Admin</button>
   </div>
 
-  <!-- Member Login / Signup Page -->
+  <!-- Login / Signup Page -->
   <div id="auth-page" class="page" style="display: none; text-align: center;">
     <h1>Account Access</h1>
-    <form data-ms-form="login" data-ms-redirect="/" style="margin-bottom: 20px;">
-      <input type="email" data-ms-member="email" placeholder="Email" required>
-      <input type="password" data-ms-member="password" placeholder="Password" required>
-      <button type="submit">Login</button>
-    </form>
-    <p>or</p>
-    <form data-ms-form="signup" data-ms-redirect="/">
-      <input type="email" data-ms-member="email" placeholder="Email" required>
-      <input type="password" data-ms-member="password" placeholder="Password" required>
-      <button type="submit">Sign Up</button>
-    </form>
-  </div>
-
-  <!-- Login Page -->
-  <div id="login-page" class="page">
-    <h1>Admin Login</h1>
-    <div style="text-align: center;">
-      <input type="password" id="admin-password" placeholder="Password">
-      <button onclick="login()">Login</button>
+    <div style="margin-bottom: 20px;">
+      <input type="text" id="login-username" placeholder="Username">
+      <input type="password" id="login-password" placeholder="Password">
+      <button onclick="loginUser()">Login</button>
     </div>
-    <p id="login-error" style="color: red; text-align: center; display: none;">Incorrect password</p>
+    <p>or</p>
+    <div>
+      <input type="text" id="signup-username" placeholder="Username">
+      <input type="password" id="signup-password" placeholder="Password">
+      <button onclick="signupUser()">Sign Up</button>
+    </div>
+    <p id="auth-error" style="color: red; display: none;"></p>
   </div>
 
   <!-- Business Interface Page -->
@@ -825,7 +814,8 @@
      * Global Data & Initialization
      ******************************/
     let sections = [];
-    let memberId = null; // Memberstack user ID
+    let userId = localStorage.getItem("userId");
+    let loggedIn = !!userId;
     const defaultSectionNames = [
       "Exteriors", 
       "Interiors", 
@@ -876,8 +866,6 @@
     let currentPage = 'business'; // Track current page
     let targetPage = null; // Track page to navigate to after save prompt
 
-    const adminPassword = "admin"; // Simple password; change for production
-    let adminLoggedIn = localStorage.getItem("adminLoggedIn") === "true";
 
 
 
@@ -1414,7 +1402,7 @@
         email: email,
         count: selectedImages.size,
         pdfBase64: pdfBase64,
-        userId: memberId
+        userId: userId
       };
       fetch('/analytics', {
         method: 'POST',
@@ -1455,7 +1443,7 @@
       const payload = {
         sections: JSON.parse(JSON.stringify(sections)),
         name: currentExperienceName || 'Untitled Experience',
-        userId: memberId
+        userId: userId
       };
       const method = editingExperienceId ? 'PUT' : 'POST';
       const url = editingExperienceId
@@ -1605,7 +1593,7 @@
       const payload = {
         name: name,
         sections: JSON.parse(JSON.stringify(sections)),
-        userId: memberId
+        userId: userId
       };
       fetch('/experiences', {
         method: 'POST',
@@ -1663,7 +1651,7 @@
           const payload = {
             name: currentExperienceName,
             sections: JSON.parse(JSON.stringify(sections)),
-            userId: memberId
+            userId: userId
           };
           fetch(`/experiences/${editingExperienceId}`, {
             method: 'PUT',
@@ -1765,7 +1753,7 @@
           const payload = {
             name: name,
             sections: JSON.parse(JSON.stringify(exp.sections)),
-            userId: memberId
+            userId: userId
           };
           fetch('/experiences', {
           method: 'POST',
@@ -1862,15 +1850,9 @@
         return;
       }
 
-      if (page === 'admin' && !adminLoggedIn) {
-        document.getElementById("login-page").style.display = 'block';
-        document.getElementById("business-page").style.display = 'none';
-        document.getElementById("client-page").style.display = 'none';
-        document.getElementById("admin-page").style.display = 'none';
-        currentPage = 'login';
+      if (!loggedIn) {
+        showAuthPage();
         return;
-      } else {
-        document.getElementById("login-page").style.display = 'none';
       }
 
       if (currentPage === 'business' && page !== 'business' && hasUnsavedChanges()) {
@@ -1915,23 +1897,60 @@
       }
     }
 
-    function login() {
-      const pass = document.getElementById("admin-password").value;
-      if (pass === adminPassword) {
-        adminLoggedIn = true;
-        safeSetItem("adminLoggedIn", "true");
-        document.getElementById("login-error").style.display = 'none';
-        document.getElementById("admin-password").value = '';
-        showPage('admin');
-      } else {
-        document.getElementById("login-error").style.display = 'block';
-      }
+    function loginUser() {
+      const username = document.getElementById('login-username').value.trim();
+      const password = document.getElementById('login-password').value;
+      fetch('/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+      })
+        .then(r => r.json())
+        .then(res => {
+          if (res.userId) {
+            userId = res.userId;
+            loggedIn = true;
+            safeSetItem('userId', userId);
+            document.getElementById('auth-error').style.display = 'none';
+            document.getElementById('auth-page').style.display = 'none';
+            document.getElementById('navbar').style.display = 'block';
+            startApp();
+          } else {
+            document.getElementById('auth-error').textContent = 'Invalid credentials';
+            document.getElementById('auth-error').style.display = 'block';
+          }
+        });
+    }
+
+    function signupUser() {
+      const username = document.getElementById('signup-username').value.trim();
+      const password = document.getElementById('signup-password').value;
+      fetch('/signup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+      })
+        .then(r => r.json())
+        .then(res => {
+          if (res.userId) {
+            userId = res.userId;
+            loggedIn = true;
+            safeSetItem('userId', userId);
+            document.getElementById('auth-error').style.display = 'none';
+            document.getElementById('auth-page').style.display = 'none';
+            document.getElementById('navbar').style.display = 'block';
+            startApp();
+          } else {
+            document.getElementById('auth-error').textContent = 'Signup failed';
+            document.getElementById('auth-error').style.display = 'block';
+          }
+        });
     }
 
     function logout() {
-      adminLoggedIn = false;
-      localStorage.removeItem("adminLoggedIn");
-      showPage('business');
+      loggedIn = false;
+      localStorage.removeItem('userId');
+      showAuthPage();
     }
     
     /********************
@@ -1965,18 +1984,18 @@
 
     function startApp() {
       if (!isClientView) {
-        const query = memberId ? `?userId=${encodeURIComponent(memberId)}` : '';
+        const query = userId ? `?userId=${encodeURIComponent(userId)}` : '';
         fetch('/experiences' + query)
           .then(r => (r.ok ? r.json() : []))
           .then(list => {
             savedExperiences = list;
-            if (adminLoggedIn) renderAdmin();
+            renderAdmin();
           });
         fetch('/analytics' + query)
           .then(r => (r.ok ? r.json() : []))
           .then(list => {
             analyticsData = list;
-            if (adminLoggedIn) renderAdmin();
+            renderAdmin();
           });
       }
       initialRender();
@@ -1990,31 +2009,12 @@
       document.getElementById('business-page').style.display = 'none';
       document.getElementById('client-page').style.display = 'none';
       document.getElementById('admin-page').style.display = 'none';
-      document.getElementById('login-page').style.display = 'none';
     }
 
-    if (window.$memberstackDom) {
-      window.$memberstackDom.getCurrentMember()
-        .then(({ data: member }) => {
-          if (member && member.id) {
-            memberId = member.id;
-            startApp();
-          } else {
-            showAuthPage();
-          }
-        })
-        .catch(showAuthPage);
-
-      window.$memberstackDom.addEventListener('member:login', ({ detail }) => {
-        if (detail && detail.member && detail.member.id) {
-          memberId = detail.member.id;
-          document.getElementById('auth-page').style.display = 'none';
-          document.getElementById('navbar').style.display = 'block';
-          startApp();
-        }
-      });
-    } else {
+    if (userId) {
       startApp();
+    } else {
+      showAuthPage();
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- replace Memberstack with basic username/password form
- store users in data.json and create default admin user
- add `/signup` and `/login` API endpoints
- save auth state in localStorage on the client

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68448efb1ce88327909a8d5c1c7c7742