### PR TITLE
Improve login design

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,6 +133,34 @@
       line-height: 1.5;
     }
 
+    /* Authentication Page */
+    .auth-box {
+      max-width: 400px;
+      margin: 0 auto;
+      text-align: center;
+    }
+
+    .auth-box input {
+      width: 100%;
+      max-width: 100%;
+      margin: 5px 0;
+    }
+
+    .auth-box .auth-btn {
+      width: 100%;
+      margin-top: 10px;
+    }
+
+    .divider {
+      margin: 15px 0;
+      font-weight: bold;
+    }
+
+    .auth-error {
+      color: red;
+      margin-top: 10px;
+    }
+
     .section-header {
       display: flex;
       align-items: baseline;
@@ -663,20 +691,22 @@
   </div>
 
   <!-- Login / Signup Page -->
-  <div id="auth-page" class="page" style="display: none; text-align: center;">
-    <h1>Account Access</h1>
-    <div style="margin-bottom: 20px;">
-      <input type="text" id="login-username" placeholder="Username">
-      <input type="password" id="login-password" placeholder="Password">
-      <button onclick="loginUser()">Login</button>
+  <div id="auth-page" class="page" style="display: none;">
+    <div class="auth-box">
+      <h1>Login</h1>
+      <div class="login-form">
+        <input type="text" id="login-username" placeholder="Username">
+        <input type="password" id="login-password" placeholder="Password">
+        <button class="auth-btn" onclick="loginUser()">Login</button>
+      </div>
+      <p class="divider">or</p>
+      <div class="signup-form">
+        <input type="text" id="signup-username" placeholder="Username">
+        <input type="password" id="signup-password" placeholder="Password">
+        <button class="auth-btn" onclick="signupUser()">Sign Up</button>
+      </div>
+      <p id="auth-error" class="auth-error" style="display: none;"></p>
     </div>
-    <p>or</p>
-    <div>
-      <input type="text" id="signup-username" placeholder="Username">
-      <input type="password" id="signup-password" placeholder="Password">
-      <button onclick="signupUser()">Sign Up</button>
-    </div>
-    <p id="auth-error" style="color: red; display: none;"></p>
   </div>
 
   <!-- Business Interface Page -->


### PR DESCRIPTION
## Summary
- restyle login/signup form for a cleaner look
- display "Login" heading instead of "Account Access"
- keep user persistence with existing localStorage logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844920260488327b242ece1ba0955fc