### PR TITLE
Fix client submissions storage

### DIFF
--- a/index.html
+++ b/index.html
@@ -854,6 +854,9 @@
     let sections = [];
     let userId = localStorage.getItem("userId");
     let loggedIn = !!userId;
+    // When viewing a shared experience link without logging in, we'll store the
+    // owning user's id so analytics can be associated with the correct account.
+    let experienceOwnerId = null;
     const defaultSectionNames = [
       "Exteriors", 
       "Interiors", 
@@ -880,6 +883,8 @@
         .then(exp => {
           sections = exp.sections || [];
           currentExperienceName = exp.name || null;
+          // Store the owning user's id so submissions can be attributed
+          experienceOwnerId = exp.userId || exp.user_id || null;
           isClientView = true;
           renderClient();
           showPage('client');
@@ -1440,7 +1445,9 @@
         email: email,
         count: selectedImages.size,
         pdfBase64: pdfBase64,
-        userId: userId
+        // Use the logged in user's id when available; otherwise fall back to the
+        // owner of the experience so the admin can see the submission.
+        userId: userId || experienceOwnerId
       };
       fetch('/analytics', {
         method: 'POST',

--- a/server.js
+++ b/server.js
@@ -120,9 +120,19 @@ async function dbGetExperience(id) {
       .eq('id', id)
       .single();
     if (error) return null;
-    return row;
+    // Normalize the user id field so the client code doesn't need to handle
+    // different property names depending on whether Supabase is used.
+    return {
+      id: row.id,
+      name: row.name,
+      sections: row.sections,
+      userId: row.user_id
+    };
   }
-  return data.experiences[id] ? { id, ...data.experiences[id] } : null;
+  const exp = data.experiences[id];
+  return exp
+    ? { id, name: exp.name, sections: exp.sections, userId: exp.userId }
+    : null;
 }
 
 async function dbUpdateExperience(id, sections, name) {


### PR DESCRIPTION
## Summary
- normalize `userId` field when fetching experiences from the server
- store the owner of the experience when viewing client links
- attach client submissions to the correct user account

## Testing
- `npm test` *(fails: Missing script)*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_684496ba4828832794d5dcb6e21b8d4e