### PR TITLE
Persist data across deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ This repository contains a simple Node server and single-page application for bu
 - `SUPABASE_URL` – URL of your Supabase project
 - `SUPABASE_KEY` – service role or anon key
 - `DATA_FILE` – optional path to JSON file used when Supabase is not configured.
-  If not provided, data is stored in `~/design-tool/data.json`, which ensures
-  your saved experiences persist even when the application code is replaced.
+  By default the server stores data in `~/design-tool/data.json` so your
+  experiences survive code updates. If you set `DATA_FILE`, make sure it points
+  outside the application directory; otherwise the file will be removed on
+  deploy and your data will be lost.
 
 Create these variables when deploying on Render or another platform.
 

--- a/server.js
+++ b/server.js
@@ -19,7 +19,19 @@ const supabase = supabaseUrl && supabaseKey && createClient
 // default location inside the user's home directory so the file isn't
 // replaced when the application code is updated.
 const DEFAULT_DATA_FILE = path.join(os.homedir(), 'design-tool', 'data.json');
-const DATA_FILE = process.env.DATA_FILE || DEFAULT_DATA_FILE;
+let DATA_FILE = process.env.DATA_FILE
+  ? path.resolve(process.env.DATA_FILE)
+  : DEFAULT_DATA_FILE;
+// Using a data path inside the app directory means the file will be lost on
+// deployments that replace the code. Detect this and fall back to the
+// persistent default path so experiences survive code updates.
+if (DATA_FILE.startsWith(path.resolve(__dirname))) {
+  console.warn(
+    `DATA_FILE ${DATA_FILE} is inside the application directory; ` +
+      `falling back to ${DEFAULT_DATA_FILE} to preserve data across deployments.`
+  );
+  DATA_FILE = DEFAULT_DATA_FILE;
+}
 let data = { experiences: {}, analytics: [], users: {} };
 if (!supabase) {
   try {


### PR DESCRIPTION
## Summary
- avoid overwriting saved experiences when code is updated by ignoring DATA_FILE paths inside the app directory
- document persistence requirements for DATA_FILE

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6844e35c135083278adf492350fa7f9e