### PR TITLE
Implement persistent login

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,9 @@ npm start
 ```
 
 The server listens on `PORT` (defaults to 3000).
+
+## Persistent Login
+
+The front-end stores the logged-in user's ID in `localStorage` so you remain
+authenticated when you refresh the page. Click **Logout** to clear the saved
+ID.

--- a/index.html
+++ b/index.html
@@ -856,8 +856,8 @@
      * Global Data & Initialization
      ******************************/
     let sections = [];
-    let userId = null;
-    let loggedIn = false;
+    let userId = localStorage.getItem('userId');
+    let loggedIn = !!userId;
     // When viewing a shared experience link without logging in, we'll store the
     // owning user's id so analytics can be associated with the correct account.
     let experienceOwnerId = null;
@@ -1962,6 +1962,7 @@
           if (res.userId) {
             userId = res.userId;
             loggedIn = true;
+            localStorage.setItem('userId', userId);
             document.getElementById('auth-error').style.display = 'none';
             document.getElementById('auth-page').style.display = 'none';
             document.getElementById('navbar').style.display = 'block';
@@ -1986,6 +1987,7 @@
           if (res.userId) {
             userId = res.userId;
             loggedIn = true;
+            localStorage.setItem('userId', userId);
             document.getElementById('auth-error').style.display = 'none';
             document.getElementById('auth-page').style.display = 'none';
             document.getElementById('navbar').style.display = 'block';
@@ -2000,6 +2002,7 @@
     function logout() {
       loggedIn = false;
       userId = null;
+      localStorage.removeItem('userId');
       showAuthPage();
     }
     


### PR DESCRIPTION
## Summary
- keep user sessions after refresh by storing `userId` in `localStorage`
- document new persistent login behavior

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6844eb9288748327a091140c733f8c40