### PR TITLE
Fix mobile PDF download and analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -1310,7 +1310,7 @@
           </tr>
         `;
         analyticsData.forEach(record => {
-          const pdfCell = record.hasPdf || record.pdfBase64
+          const pdfCell = record.pdfBase64
             ? `<button class="saved-experience-btn" onclick="downloadUserPDF('${record.id}')">Download PDF</button>`
             : "No PDF available";
           table.innerHTML += `
@@ -1454,68 +1454,52 @@
         }
       }
 
-      const pdfBlob = pdf.output('blob');
+      const pdfBase64 = pdf.output('datauristring');
       const pdfId = Date.now().toString();
 
       const record = {
         id: pdfId,
         email: email,
         count: selectedImages.size,
+        pdfBase64: pdfBase64,
         userId: userId || experienceOwnerId
       };
 
-      const reader = new FileReader();
-      reader.onloadend = async function() {
-        record.pdfBase64 = reader.result;
-        try {
-          const json = JSON.stringify(record);
-          if (navigator.sendBeacon) {
-            const blob = new Blob([json], { type: 'application/json' });
-            navigator.sendBeacon('/analytics', blob);
-          } else {
-            const resp = await fetch('/analytics', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: json
-            });
-            if (!resp.ok) throw new Error();
-          }
-          analyticsData.push({ id: record.id, email: record.email, count: record.count, hasPdf: true });
-          saveAnalyticsToLocal();
-          renderAdmin();
-        } catch {
-          alert('Failed to store analytics.');
-        } finally {
-          const url = URL.createObjectURL(pdfBlob);
-          const link = document.createElement('a');
-          link.href = url;
-          link.download = 'gehl-homes-brochure.pdf';
-          document.body.appendChild(link);
-          link.click();
-          document.body.removeChild(link);
-          URL.revokeObjectURL(url);
+      try {
+        const json = JSON.stringify(record);
+        if (navigator.sendBeacon) {
+          const blob = new Blob([json], { type: 'application/json' });
+          navigator.sendBeacon('/analytics', blob);
+        } else {
+          const resp = await fetch('/analytics', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: json
+          });
+          if (!resp.ok) throw new Error();
         }
-      };
-      reader.readAsDataURL(pdfBlob);
+        analyticsData.push(record);
+        saveAnalyticsToLocal();
+        renderAdmin();
+      } catch {
+        alert('Failed to store analytics.');
+      }
+
+      pdf.save('gehl-homes-brochure.pdf');
     }
 
     function downloadUserPDF(pdfId) {
-      fetch(`/analytics/${pdfId}/pdf`)
-        .then(resp => {
-          if (!resp.ok) throw new Error();
-          return resp.blob();
-        })
-        .then(blob => {
-          const url = URL.createObjectURL(blob);
-          const link = document.createElement('a');
-          link.href = url;
-          link.download = `client-brochure-${pdfId}.pdf`;
-          document.body.appendChild(link);
-          link.click();
-          document.body.removeChild(link);
-          URL.revokeObjectURL(url);
-        })
-        .catch(() => alert('PDF not available for download.'));
+      const record = analyticsData.find(rec => rec.id === pdfId);
+      if (record && record.pdfBase64) {
+        const link = document.createElement('a');
+        link.href = record.pdfBase64;
+        link.download = `client-brochure-${pdfId}.pdf`;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+      } else {
+        alert("PDF not available for download.");
+      }
     }
 
     function deleteSubmission(id) {

--- a/server.js
+++ b/server.js
@@ -195,21 +195,7 @@ async function dbInsertAnalytics(record) {
     if (error) throw error;
     return true;
   }
-  const { pdfBase64, ...rest } = record;
-  let pdfPath = null;
-  if (pdfBase64) {
-    try {
-      const base64 = pdfBase64.split(',')[1];
-      const buffer = Buffer.from(base64, 'base64');
-      const dir = path.join(os.homedir(), 'design-tool', 'pdfs');
-      fs.mkdirSync(dir, { recursive: true });
-      pdfPath = path.join(dir, `${record.id}.pdf`);
-      fs.writeFileSync(pdfPath, buffer);
-    } catch (e) {
-      console.error('Failed to store PDF:', e);
-    }
-  }
-  data.analytics.push({ ...rest, pdfPath });
+  data.analytics.push(record);
   saveData();
   return true;
 }
@@ -227,13 +213,7 @@ async function dbListAnalytics(userId) {
   }
   return data.analytics
     .filter(a => (a.userId ?? a.user_id) === userId)
-    .map(a => ({
-      id: a.id,
-      email: a.email,
-      count: a.count,
-      userId: a.userId ?? a.user_id,
-      hasPdf: !!a.pdfPath
-    }));
+    .map(a => ({ ...a, userId: a.userId ?? a.user_id }));
 }
 
 async function dbDeleteAnalytics(id) {
@@ -244,33 +224,11 @@ async function dbDeleteAnalytics(id) {
   }
   const idx = data.analytics.findIndex(a => a.id === id);
   if (idx !== -1) {
-    const rec = data.analytics[idx];
-    if (rec.pdfPath) {
-      try { fs.unlinkSync(rec.pdfPath); } catch {}
-    }
     data.analytics.splice(idx, 1);
     saveData();
     return true;
   }
   return false;
-}
-
-async function dbGetAnalyticsPdf(id) {
-  if (supabase) {
-    const { data: row, error } = await supabase
-      .from('analytics')
-      .select('pdfBase64')
-      .eq('id', id)
-      .single();
-    if (error || !row || !row.pdfBase64) return null;
-    const base64 = row.pdfBase64.split(',')[1];
-    return Buffer.from(base64, 'base64');
-  }
-  const rec = data.analytics.find(a => a.id === id);
-  if (rec && rec.pdfPath && fs.existsSync(rec.pdfPath)) {
-    return fs.readFileSync(rec.pdfPath);
-  }
-  return null;
 }
 
 const server = http.createServer(async (req, res) => {
@@ -438,24 +396,6 @@ const server = http.createServer(async (req, res) => {
     }
   }
 
-  if (req.method === 'GET' && url.pathname.startsWith('/analytics/') && url.pathname.endsWith('/pdf')) {
-    const id = url.pathname.split('/')[2];
-    try {
-      const pdfBuffer = await dbGetAnalyticsPdf(id);
-      if (!pdfBuffer) {
-        res.writeHead(404, { 'Content-Type': 'text/plain' });
-        res.end('Not found');
-        return;
-      }
-      res.writeHead(200, { 'Content-Type': 'application/pdf' });
-      res.end(pdfBuffer);
-    } catch (e) {
-      console.error(e);
-      res.writeHead(500, { 'Content-Type': 'text/plain' });
-      res.end('Server error');
-    }
-    return;
-  }
 
   if (req.method === 'DELETE' && url.pathname.startsWith('/analytics/')) {
     const id = url.pathname.split('/')[2];


### PR DESCRIPTION
## Summary
- revert slow PDF handling that streamed PDFs from the server
- send analytics via `navigator.sendBeacon` but keep inline PDF data
- restore fast PDF downloads for admins

## Testing
- `node -c server.js`

------
https://chatgpt.com/codex/tasks/task_e_6844fd54a5ac8327ae65cf97cfaf9b1c