### PR TITLE
Update supabase-js dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@supabase/supabase-js": "^2.15.0",
+    "@supabase/supabase-js": "^2.52.0",
     "dotenv": "^16.3.1"
   }
 }


### PR DESCRIPTION
## Summary
- update `@supabase/supabase-js` to the newer 2.52.0 release

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_687d5ba16cf0832793fe3515663f943c