### PR TITLE
Add image upload endpoint and update server

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.52.0",
-    "dotenv": "^16.3.1"
+    "dotenv": "^16.3.1",
+    "multer": "^1.4.5-lts.1"
   }
 }


### PR DESCRIPTION
## Summary
- support local or Supabase image uploads
- log storage mode and warn when not using Supabase
- add CORS allowances for PUT and DELETE
- expose uploaded images and `/upload-image` endpoint
- include `multer` in dependencies

## Testing
- `node -c server.js`
- `npm install` *(fails: `403 Forbidden`)*

------
https://chatgpt.com/codex/tasks/task_e_687d81162f788327bd22ef110008a199