### PR TITLE
Persist user data after updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ This repository contains a simple Node server and single-page application for bu
   on platforms such as Render you should use a persistent volume or external
   database and set `DATA_FILE` to that path (for example `/var/data/data.json`).
   If the file lives inside the application directory it will be removed whenever
-  the service restarts and all experiences and submissions will be lost.
+  the service restarts and all experiences and submissions will be lost. The
+  server automatically migrates a legacy `data.json` from the application
+  directory to this persistent location on first startup so existing data isn't
+  lost when you update the code.
 - `STRIPE_SECRET_KEY` – optional, your Stripe secret key for paid subscriptions
 - `STRIPE_PRICE_ID` – optional, the Stripe price ID used for checkout
   (if these are omitted, subscription and payment features are disabled)

--- a/server.js
+++ b/server.js
@@ -49,6 +49,19 @@ if (DATA_FILE.startsWith(path.resolve(__dirname))) {
   );
   DATA_FILE = DEFAULT_DATA_FILE;
 }
+// If a legacy data.json exists in the application directory but the
+// persistent file does not yet, migrate the old data to the new location so
+// saved experiences survive code updates.
+const LEGACY_DATA_FILE = path.join(__dirname, 'data.json');
+if (!fs.existsSync(DATA_FILE) && fs.existsSync(LEGACY_DATA_FILE)) {
+  try {
+    fs.mkdirSync(path.dirname(DATA_FILE), { recursive: true });
+    fs.copyFileSync(LEGACY_DATA_FILE, DATA_FILE);
+    console.log(`Migrated data file from ${LEGACY_DATA_FILE} to ${DATA_FILE}`);
+  } catch (e) {
+    console.error('Failed to migrate legacy data file:', e);
+  }
+}
 let data = { experiences: {}, analytics: [], users: {} };
 if (!supabase) {
   console.log('Using local data file at ' + DATA_FILE);


### PR DESCRIPTION
## Summary
- migrate any old `data.json` in the app directory to the new persistent storage location
- document the automatic migration in README

## Testing
- `npm start` *(fails: Cannot find module 'multer')*

------
https://chatgpt.com/codex/tasks/task_e_687d9363c2d483278851c2e8ffcead84